### PR TITLE
Change Error Logging

### DIFF
--- a/Jellyfin.Plugin.Simkl/Services/PlaybackScrobbler.cs
+++ b/Jellyfin.Plugin.Simkl/Services/PlaybackScrobbler.cs
@@ -98,7 +98,7 @@ namespace Jellyfin.Plugin.Simkl.Services
                 var userConfig = SimklPlugin.Instance?.Configuration.GetByGuid(userId);
                 if (userConfig == null || string.IsNullOrEmpty(userConfig.UserToken))
                 {
-                    _logger.LogError(
+                    _logger.LogInformation(
                         "Can't scrobble: User {UserName} not logged in ({UserConfigStatus})",
                         eventArgs.Session.UserName,
                         userConfig == null);


### PR DESCRIPTION
Currently, when a SIMKL user is not set, it will log as an error, when in reality it's not really an error as some users may not have a SIMKL account.

To clean up the log files, changing to an info would better suit.