### PR TITLE
Fix: prevent false negative scrobbles for already tracked items

### DIFF
--- a/Jellyfin.Plugin.Simkl/API/SimklApi.cs
+++ b/Jellyfin.Plugin.Simkl/API/SimklApi.cs
@@ -122,9 +122,11 @@ namespace Jellyfin.Plugin.Simkl.API
             _logger.LogDebug("BaseItem: {@Item}", item);
             _logger.LogDebug("History: {@History}", history);
             _logger.LogDebug("Response: {@Response}", r);
-            if (r != null && history.Movies.Count == r.Added.Movies
-                && history.Shows.Count == r.Added.Shows
-                && history.Episodes.Count == r.Added.Episodes)
+            if (r != null
+                && r.NotFound != null
+                && r.NotFound.Movies.Length == 0
+                && r.NotFound.Shows.Length == 0
+                && r.NotFound.Episodes.Length == 0)
             {
                 return (true, item);
             }
@@ -143,9 +145,13 @@ namespace Jellyfin.Plugin.Simkl.API
             }
 
             r = await SyncHistoryAsync(history, userToken);
-            return r == null
-                ? (false, item)
-                : (history.Movies.Count == r.Added.Movies && history.Shows.Count == r.Added.Shows, item);
+            return r != null
+                && r.NotFound != null
+                && r.NotFound.Movies.Length == 0
+                && r.NotFound.Shows.Length == 0
+                && r.NotFound.Episodes.Length == 0
+                    ? (true, item)
+                    : (false, item);
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

Re-scrobbling an already watched item was incorrectly treated as a failed sync.
This occurred when re-syncing items (e.g. after a rewatch), where marking them as watched again does not produce new Added entries in the API response.
As a result, the system would trigger unnecessary retry logic and additional sync requests, leading to avoidable calls to the external API.

## Root Cause

The success condition was based on comparing Added counts between the request and response.
However, when an item is already tracked, the API may not return it in Added, causing a false negative even though the operation actually succeeded.

This incorrect assumption caused the system to:
- Misinterpret successful syncs as failures
- Trigger fallback logic
- Perform additional, redundant API requests

## Solution

Aligned the success logic with the API behavior by checking the NotFound section of the response instead.

This ensures:
- Consistent success detection with the initial sync logic
- Proper handling of repeated sync attempts
- Elimination of unnecessary fallback logic and redundant API calls

## Logs Explanation

The following logs show a playback stop event followed by an attempt to sync (scrobble) the item to the external service.

- **Playback stopped**: the client reports that playback ended
- **Trying to scrobble**: the system prepares the history payload using metadata and file path
- **Syncing History**: the sync request is sent to the API
- **Posting**: fallback logic that attempts identification via file data when the first sync is not considered successful

Sensitive data such as file paths, IDs, and hashes have been redacted.

With the fix
```
[INF] Playback stopped reported by app "Jellyfin Web" "<version>" playing "<movie>". Stopped at "<position>" ms
[INF] Trying to scrobble "<movie>" (<item-id>) for "<user>" (<user-id>) - "<redacted-path>" on "<device-id>"
[INF] Syncing History
```

✅ The flow stops here because the sync is correctly considered successful, avoiding unnecessary API calls.

Without the fix
```
[INF] Playback stopped reported by app "Jellyfin Web" "<version>" playing "<movie>". Stopped at "<position>" ms
[INF] Trying to scrobble "<movie>" (<item-id>) for "<user>" (<user-id>) - "<redacted-path>" on "<device-id>"
[INF] Syncing History
[INF] Posting: SimklFile { File: "<redacted-path>", Part: null, Hash: null }
[INF] Syncing History
```

⚠️ The system incorrectly assumes failure and triggers a fallback:

The system incorrectly assumes failure and triggers fallback logic:
- Attempts to re-identify the item using the file path (Posting)
- Performs an additional, unnecessary sync request
- Introduces redundant load on the external API

## Testing
- Verified that syncing already watched items no longer returns false negatives
- Confirmed that fallback logic is no longer triggered unnecessarily
- Ensured no regressions for new items being synced

Note: This message was written with AI assistance as English is not my primary language.